### PR TITLE
WW-3647: Update default checkbox icon to match new icon system

### DIFF
--- a/ww-config.js
+++ b/ww-config.js
@@ -94,7 +94,7 @@ export default {
                 content: {
                     color: '#FFFFFF',
                     fontSize: 10,
-                    icon: 'fas fa-check',
+                    icon: 'check',
                 },
                 state: {
                     states: [{ id: 'checked', label: 'checked' }],


### PR DESCRIPTION
Updated the default icon from 'fas fa-check' to 'check' to match the new icon system implementation in ww-checkbox component.